### PR TITLE
继续准备结构体

### DIFF
--- a/src/frontend/e.l
+++ b/src/frontend/e.l
@@ -35,6 +35,12 @@ MULTI_COMMENT				"/*"([^\*]|(\*)*[^\*/])*(\*)*"*/"
 "float"  					{ return FLOAT; }
 "double"  					{ return DOUBLE; }
 "char"						{ return CHAR; }
+"int_ptr" 					{ return INT_PTR; }
+"long_ptr" 					{ return LONG_PTR; }
+"float_ptr" 				{ return FLOAT_PTR; }
+"long_ptr" 					{ return LONG_PTR; }
+"char_ptr" 					{ return CHAR_PTR; }
+"struct"  					{ return STRUCT; }
 "input"  					{ return INPUT; }
 "output"  					{ return OUTPUT; }
 "return"  					{ return RETURN; }

--- a/src/frontend/e_proc.c
+++ b/src/frontend/e_proc.c
@@ -283,6 +283,24 @@ struct op *process_expression_list(struct op *arg_list_pre,
 /**************************************/
 /************* statement **************/
 /**************************************/
+struct op *process_struct_definition(char *name, struct op *definition_block){
+	struct op *id_op = new_op();
+
+	struct id *var = add_identifier(name, ID_STRUCT, NO_TYPE, NO_INDEX, NOT_POINTER);
+
+	return id_op;
+}
+
+struct op *process_definition(int data_type, struct op *definition_list){
+	
+	return 0;
+}
+
+struct op *process_add_member(char *name, int index){
+	
+	return 0;
+}
+
 // 处理变量声明，为process_variable函数声明的变量加上类型
 struct op *process_declaration(int data_type, struct op *declaration_exp) {
 	struct op *declaration = new_op();
@@ -301,16 +319,6 @@ struct op *process_declaration(int data_type, struct op *declaration_exp) {
 	cat_op(declaration, declaration_exp);
 
 	return declaration;
-}
-
-// 处理变量声明，向符号表加入尚未初始化类型的变量
-struct op *process_variable_list(struct op *var_list_pre, struct op *id_op) {
-	struct op *variable_list = new_op();
-
-	cat_op(variable_list, var_list_pre);
-	cat_op(variable_list, id_op);
-
-	return variable_list;
 }
 
 static void push_block_stack(struct id *label_begin, struct id *label_end) {

--- a/src/include/e_proc.h
+++ b/src/include/e_proc.h
@@ -17,9 +17,10 @@ struct op *process_add_identifier(char *name, int index);
 struct op *process_array_identifier(struct op *array_op, int index);
 struct op *process_identifier(char *name);
 
+struct op *process_struct_definition(char *name, struct op *definition_block);
+struct op *process_definition(int data_type, struct op *definition_list);
+struct op *process_add_member(char *name, int index);
 struct op *process_declaration(int data_type, struct op *exp_1);
-struct op *process_variable_list_head(struct op *id_op);
-struct op *process_variable_list(struct op *exp_1, struct op *id_op);
 struct op *process_assign(struct op *leftval, struct op *exp_1);
 struct op *process_derefer_put(struct op *id_op);
 struct op *process_derefer_get(struct op *id_op);

--- a/src/include/e_tac.h
+++ b/src/include/e_tac.h
@@ -45,6 +45,7 @@
 #define ID_NUM 3     // 数字常量
 #define ID_LABEL 4   // 标签
 #define ID_STRING 5  // 字符串
+#define ID_STRUCT 6  // 结构体
 
 // 数据类型
 #define PTR_OFFSET 10


### PR DESCRIPTION
- 将结构体加入了e.y
- 不再有int *式的声明了，只有int_ptr。这是为了避免和c-type声明混淆，因为做不到int a,*b式的声明